### PR TITLE
Update and Document Release flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - ".github/workflows/deploy.yml"
+      - "setup.py"
 
 jobs:
   test:
@@ -43,7 +46,7 @@ jobs:
       - name: Install Plugin
         run: pip install -e .
       - name: Build Example Docs
-        working-directory: 'sample-docs/'
+        working-directory: "sample-docs/"
         run: |
           mkdocs build --theme material \
                 --site-dir ../site/monorepo-example/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -157,5 +157,7 @@ $ PYTHON_37_ONLY=1 ./__tests__/test-local.sh
 
 Feel free to open up a PR and share why you think this change is valuable (unless it's something obvious, like a typo or confirmed bug). Assuming it is a change that is wanted, a maintainer will take a look to see if there's any changes needed.
 
+To make a new release, make sure to update the version in `setup.py` and add a new entry in the [CHANGELOG.md](CHANGELOG.md).
+
 [mkdocs material]: https://squidfunk.github.io/mkdocs-material/
 [github actions]: https://github.com/features/actions


### PR DESCRIPTION
Closes https://github.com/backstage/mkdocs-monorepo-plugin/issues/38

Similar to https://github.com/backstage/mkdocs-techdocs-core/blob/main/.github/workflows/pypi-publish.yml this PR updates the publish workflow to run only when `setup.py` is updated.