### PR TITLE
Update license headers and license section in readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Spotify AB
+   Copyright 2020 The Backstage Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ $ tree ./site
 
 ## License
 
-Released under the Apache 2.0 License. See [here](./LICENSE) for more details.
+Copyright 2020-2021 © The Backstage Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 
 ## Contributing
 

--- a/mkdocs_monorepo_plugin/merger.py
+++ b/mkdocs_monorepo_plugin/merger.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Spotify AB
+# Copyright 2020 The Backstage Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Spotify AB
+# Copyright 2020 The Backstage Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mkdocs_monorepo_plugin/plugin.py
+++ b/mkdocs_monorepo_plugin/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Spotify AB
+# Copyright 2020 The Backstage Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Make copyright headers same as the https://github.com/backstage/backstage repo