### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ tree ./site
 
 ### Release
 
-1. Update the [Changelog](https://github.com/backstage/mkdocs-monorepo-plugin/blob/main/README.md#changelog).
+1. Update the [CHANGELOG.md](./docs/CHANGELOG.md).
 2. Bump up the version number in `setup.py` which triggers the release workflow on [GitHub Actions](.github/workflows/deploy.yml) to publish a new version in PyPI.
 
 ## Supported Versions
@@ -153,9 +153,7 @@ $ tree ./site
 
 ## Changelog
 
-### 0.4.3
-
-- First release
+Check out our [CHANGELOG.md](./docs/CHANGELOG.md) for details.
 
 ## License
 


### PR DESCRIPTION
Updated the **Changelog** section (that just listed one version and was out of synch with the docs/CHANGELOG.md file) to include a link to the CHANGELOG.md file instead. 
Also updated the **Release** section to also refer to the CHANGELOG.md file instead of the existing link to bookmark (that was a 404).