### PR TITLE
Fix TypeError when nav is generated automatically

### DIFF
--- a/mkdocs_monorepo_plugin/plugin.py
+++ b/mkdocs_monorepo_plugin/plugin.py
@@ -28,6 +28,7 @@ class MonorepoPlugin(BasePlugin):
     def on_config(self, config):
         # If no 'nav' defined, we don't need to run.
         if not config.get('nav'):
+            self.originalDocsDir = config['docs_dir']
             return config
 
         # Handle !import statements


### PR DESCRIPTION
if `nav` is not specified in `mkdocs.yml`, the entire `on_config` function body is skipped but `on_serve` relies on `self.originalDocsDir`.