### PR TITLE
Update the 'does not contain nav' messaging to include 'docs_dir' option

### DIFF
--- a/__tests__/integration/test.bats
+++ b/__tests__/integration/test.bats
@@ -195,7 +195,7 @@ teardown() {
 @test "fails if !include path docs_dir does not contain any files" {
   cd ${fixturesDir}/error-no-nav-no-docs
   assertFailedMkdocs build
-  [[ "$output" == *"[mkdocs-monorepo] The file path /"*"/__tests__/integration/fixtures/error-no-nav-no-docs/project-a/mkdocs.yml does not contain a valid 'nav' key in the YAML file. Please include it to indicate how your documentation should be presented in the navigation."* ]]
+  [[ "$output" == *"[mkdocs-monorepo] The file path /"*"/__tests__/integration/fixtures/error-no-nav-no-docs/project-a/mkdocs.yml does not contain a valid 'nav' key in the YAML file. Please include it to indicate how your documentation should be presented in the navigation, or include a 'docs_dir' to indicate that automatic nav generation should be used."* ]]
 }
 
 @test "fails if absolute links aren't supported" {

--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -197,7 +197,8 @@ class IncludeNavLoader:
             log.critical(
                 "[mkdocs-monorepo] The file path {} ".format(self.absNavPath) +
                 "does not contain a valid 'nav' key in the YAML file. " +
-                "Please include it to indicate how your documentation should be presented in the navigation."
+                "Please include it to indicate how your documentation should be presented in the navigation, " +
+                "or include a 'docs_dir' to indicate that automatic nav generation should be used."
             )
             raise SystemExit(1)
 


### PR DESCRIPTION
Thanks to waltermaldonado's excellent PR #35, it's possible for the plugin to use the implicit nav generation, just by specifying `docs_dir` in the included site's `mkdocs.yml`.

This change just makes that fact obvious in the error message.

I recently revisited this project, assumed you still had to explicitly define each site's nav, and was pleasantly surprised to find you didn't have to. I only discovered this by looking at the source code though!

Let me know if this requires an additional test, or if anybody has a more elegant way of wording the message :grimacing: 