### PR TITLE
[GOG-533] Modified plugin to support wildcard include statement

### DIFF
--- a/sample-docs/components/a/docs/README.md
+++ b/sample-docs/components/a/docs/README.md
@@ -1,0 +1,1 @@
+# Docs for A

--- a/sample-docs/components/a/mkdocs.yml
+++ b/sample-docs/components/a/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Component A
+
+nav:
+  - Home: "README.md"

--- a/sample-docs/components/b/docs/README.md
+++ b/sample-docs/components/b/docs/README.md
@@ -1,0 +1,1 @@
+# Docs for B

--- a/sample-docs/components/b/mkdocs.yml
+++ b/sample-docs/components/b/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Component B
+
+nav:
+  - Home: "README.md"

--- a/sample-docs/components/c/docs/README.md
+++ b/sample-docs/components/c/docs/README.md
@@ -1,0 +1,1 @@
+# Docs for C

--- a/sample-docs/components/c/mkdocs.yml
+++ b/sample-docs/components/c/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Component C
+
+nav:
+  - Home: "README.md"

--- a/sample-docs/components/d/README.md
+++ b/sample-docs/components/d/README.md
@@ -1,0 +1,1 @@
+# Component D

--- a/sample-docs/mkdocs.yml
+++ b/sample-docs/mkdocs.yml
@@ -3,6 +3,7 @@ site_name: Cats API
 nav:
   - Intro: 'index.md'
   - Authentication: 'authentication.md'
+  - '*include ./components/* Components': '!include .'
   - API:
     - v1: '!include ./v1/mkdocs.yml'
     - v2: '!include ./v2/mkdocs.yml'


### PR DESCRIPTION
This is a modified plugin based on https://github.com/backstage/mkdocs-monorepo-plugin that supports new syntax to enable including all of the docs for components (e.g in nitro-web or tempo) using a wildcard syntax rather than explicitly. There is a sample project in the mkdocs-monorepo-wildcard-plugin/sample-docs folder that demonstrates the syntax. 

```
site_name: Cats API

nav:
  - Intro: 'index.md'
  - Authentication: 'authentication.md'
  - '*include ./components/* Components': '!include .'
...

plugins:
  - monorepo
  ```