### PR TITLE
fix: don't run on_serve if on_config was skipped

### DIFF
--- a/__tests__/test-ci.sh
+++ b/__tests__/test-ci.sh
@@ -5,6 +5,9 @@ echo "Running flake8 linter -------->"
 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=setup.py
 flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=setup.py
 
+# Running unit-tests
+python3 -m unittest
+
 # End-to-end testing via Bats (Bash automated tests)
 GITHUB_ACTIONS_E2E_PATH="/home/runner/work/mkdocs-monorepo-plugin/mkdocs-monorepo-plugin/__tests__/integration/test.bats"
 LOCAL_E2E_PATH="./integration/test.bats"

--- a/__tests__/test-local.sh
+++ b/__tests__/test-local.sh
@@ -5,6 +5,9 @@ echo "Running flake8 linter -------->"
 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=setup.py
 flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=setup.py
 
+# Running unit-tests
+python3 -m unittest
+
 # End-to-end testing via Bats (Bash automated tests)
 function docker_run_integration_tests() {
 docker build -t mkdocs-monorepo-test-runner:$1 --quiet -f- . <<EOF

--- a/mkdocs_monorepo_plugin/plugin.py
+++ b/mkdocs_monorepo_plugin/plugin.py
@@ -70,26 +70,27 @@ class MonorepoPlugin(BasePlugin):
     def on_serve(self, server, config, **kwargs):
         # Watch extra files only if this plugin was actually initialized with
         # `on_config`
-        if self.originalDocsDir is not None:
-            # Support mkdocs < 1.2
-            if hasattr(server, 'watcher'):
-                buildfunc = list(server.watcher._tasks.values())[0]['func']
+        if self.originalDocsDir is None:
+            return
+        # Support mkdocs < 1.2
+        if hasattr(server, 'watcher'):
+            buildfunc = list(server.watcher._tasks.values())[0]['func']
 
-                # still watch the original docs/ directory
-                server.watch(self.originalDocsDir, buildfunc)
+            # still watch the original docs/ directory
+            server.watch(self.originalDocsDir, buildfunc)
 
-                # watch all the sub docs/ folders
-                for _, docs_dir, yaml_file in self.resolvedPaths:
-                    server.watch(yaml_file, buildfunc)
-                    server.watch(docs_dir, buildfunc)
-            else:
-                # still watch the original docs/ directory
-                server.watch(self.originalDocsDir)
+            # watch all the sub docs/ folders
+            for _, docs_dir, yaml_file in self.resolvedPaths:
+                server.watch(yaml_file, buildfunc)
+                server.watch(docs_dir, buildfunc)
+        else:
+            # still watch the original docs/ directory
+            server.watch(self.originalDocsDir)
 
-                # watch all the sub docs/ folders
-                for _, docs_dir, yaml_file in self.resolvedPaths:
-                    server.watch(yaml_file)
-                    server.watch(docs_dir)
+            # watch all the sub docs/ folders
+            for _, docs_dir, yaml_file in self.resolvedPaths:
+                server.watch(yaml_file)
+                server.watch(docs_dir)
 
     def post_build(self, config):
         self.merger.cleanup()

--- a/mkdocs_monorepo_plugin/tests/test_plugin.py
+++ b/mkdocs_monorepo_plugin/tests/test_plugin.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import unittest
+from mkdocs_monorepo_plugin import plugin as p
+
+
+class MockServer():
+    """MockServer tracks what the livereload.Server instance is watching."""
+
+    def __init__(self):
+        self.watched = []
+
+    def watch(self, input):
+        self.watched.append(input)
+
+
+class TestMonorepoPlugin(unittest.TestCase):
+    def test_plugin_on_config_defaults(self):
+        plugin = p.MonorepoPlugin()
+        plugin.on_config({})
+        self.assertIsNone(plugin.originalDocsDir)
+
+    def test_plugin_on_config_with_nav(self):
+        plugin = p.MonorepoPlugin()
+        plugin.on_config({
+                    "nav": {"page1": "page1.md"},
+                    "docs_dir": "docs"
+                })
+        self.assertEqual(plugin.originalDocsDir, "docs")
+
+    def test_plugin_on_serve_no_run(self):
+        plugin = p.MonorepoPlugin()
+        plugin.originalDocsDir = None
+        server = MockServer()
+        plugin.on_serve(server, {})
+        self.assertEqual(server.watched, [])
+
+    def test_plugin_on_serve(self):
+        plugin = p.MonorepoPlugin()
+        plugin.originalDocsDir = "docs"
+        plugin.resolvedPaths = []
+        server = MockServer()
+        plugin.on_serve(server, {})
+        self.assertSetEqual(set(server.watched), {
+            "docs"
+            })


### PR DESCRIPTION
I didn't mean to steal @gferon 's thunder, but I saw that #62 was somewhat stale. I decided to review the code a little bit and I discovered that the whole of on_serve should be skipped entirely if on_config didn't run, since there would therefore be no extra files to livereload to watch.

I do have some outstanding questions -- do we want to augment our github actions workflows to also run these unit tests?

Also, I'm going to have to apologize if I'm not following some style guides; it's been a while since I've written python!

## Architecture
Since this plugin is not functional without nav, on_config detects
whether this needs to be run as a first step, and returns immediately if
it is not found.

However, currently on_serve fails with a TypeError if on_config returns
immediately, since it tries to server.watch(None). Therefore, we should
also skip on_serve if on_config never ran in the first place.

## Other changes
- Added tests folder inside of the plugin -- run with `python3 -m
  unittest` on the root of the repository
