### PR TITLE
skip on_serve if self.originalDocsDir is None

### DIFF
--- a/mkdocs_monorepo_plugin/plugin.py
+++ b/mkdocs_monorepo_plugin/plugin.py
@@ -64,6 +64,11 @@ class MonorepoPlugin(BasePlugin):
         return page
 
     def on_serve(self, server, config, **kwargs):
+        # We didn't preprocess this repo / create a new docs directory
+        # so we don't need to watch the original docs dir.
+        if self.originalDocsDir is None:
+            return
+
         # Support mkdocs < 1.2
         if hasattr(server, 'watcher'):
             buildfunc = list(server.watcher._tasks.values())[0]['func']


### PR DESCRIPTION
this is a simpler alternative to #69 that i'm _only putting up_ in the interest of expediency as we want to push out backstage techdocs in our org and plan to recommend techdocs-cli (specifically serve w/ hotreload) for local development! we'd prefer not to force repos to include a `nav` mkdocs directive if it's only required due to a bug in this plugin 

resolves https://github.com/backstage/backstage/issues/8110 