### PR TITLE
Fix incompatibility with mkdocs v1.4.0

### DIFF
--- a/__tests__/integration/test.bats
+++ b/__tests__/integration/test.bats
@@ -304,7 +304,7 @@ teardown() {
   assertFileNotContains './site/test/other/other/index.html' 'href="https://github.com/backstage/mkdocs-monorepo-plugin/edit/master/__tests__/integration/fixtures/ok-include-path-no-repo-url/api/docs/other/other.md"'
 }
 
-@test "does not default to root edit_uri if it is not configured" {
+@test "does not default to root edit_uri if it is not configured for wildcard paths" {
   cd ${fixturesDir}/ok-include-wildcard-no-repo-url
   assertSuccessMkdocs build
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4
+
+-   Resolve a bug that prevented this plugin from working with mkdocs >= v1.4.0
+
 ## 1.0.3
 
 -   Allow no specification for both ´nav´ and ´docs_dir´

--- a/mkdocs_monorepo_plugin/edit_uri.py
+++ b/mkdocs_monorepo_plugin/edit_uri.py
@@ -56,7 +56,7 @@ class EditUrl:
 
     root_docs_dir = self.__get_root_docs_dir()
     root_repo_url = self.config.get('repo_url')
-    root_edit_uri = self.config.get('edit_uri', '')
+    root_edit_uri = self.config.get('edit_uri', '') or ''
 
     page_docs_dir = self.__get_page_docs_dir()
     page_repo_url = config.get('repo_url', root_repo_url)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='mkdocs-monorepo-plugin',
-    version='1.0.3',
+    version='1.0.4',
     description='Plugin for adding monorepository support in Mkdocs.',
     long_description="""
         This introduces support for the !include syntax in mkdocs.yml, allowing you to import additional Mkdocs navigation.


### PR DESCRIPTION
## What / Why

Looks like [this change](https://github.com/mkdocs/mkdocs/pull/2927/files), released in [`mkdocs` v1.4.0](https://www.mkdocs.org/about/release-notes/#version-140-2022-09-27) slightly changed the way the `edit_uri` config behaves when it is not set.  ...A small change will allow us to support this again.

## How to test

1. Manually update `requirements.txt` to use `mkdocs>=1.4.0`
2. Run the test suite locally `PYTHON_37_ONLY=1 ./__tests__/test-local.sh`

Without the change to `edit_uri.py`, the test suite should fail numerous cases.  _With_ the change, all tests should pass.