### PR TITLE
make example yaml code better readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ nav:
 plugins:
   - monorepo
 
+```
+```yaml
 # /src/v1/mkdocs.yml
 site_name: versions/v1
 
@@ -54,6 +56,8 @@ nav:
   - Reference: "reference.md"
   - Changelog: "changelog.md"
 
+```
+```yaml
 # /src/v2/mkdocs.yml
 site_name: versions/v2
 


### PR DESCRIPTION
I first thought that this was all written in a global mkdocs.yaml file, and the #commented file names are part of the "special" syntax. Splitting these files visually could improve readability.

If you are not d'accord, just delete this PR. 