### PR TITLE
Allow cross-referencing in nav

### DIFF
--- a/__tests__/integration/fixtures/ok-cross-reference/docs/cross.md
+++ b/__tests__/integration/fixtures/ok-cross-reference/docs/cross.md
@@ -1,0 +1,3 @@
+# Cross-referenced
+
+This is included in project-a's nav

--- a/__tests__/integration/fixtures/ok-cross-reference/docs/index.md
+++ b/__tests__/integration/fixtures/ok-cross-reference/docs/index.md
@@ -1,0 +1,53 @@
+# Neptunia vapor
+
+## Has mente et
+
+Lorem markdownum aequora Famemque, a ramos regna Ulixem verba, posito qui
+nubilus membra. Pendet dixit canisve, hanc quoque animosa **veni**, inducere.
+Fer quem, mihi vallem; reposcunt aequoreae Haec, inposita. Eras dicere sic! Ore
+ad at nec pius rivi pectora Pandione amari pietas Ulixem.
+
+> Argenteus sinit. Corpore non Booten Uranie, in hac has dixi herbas. *Oculos
+> omnes Dixerat* suae coloribus et antris spernitque silva, dixit.
+
+Mihi [quamvis](http://caput-latebris.com/), ardua venit nam, de mox in et inquit
+incisa relevare reseminet Cycnus forma sororis. In mater artus utque iustis me
+vestrae magno datque, quaque multumque oscula iubemur.
+
+## Aditumque ubi
+
+Brevibus cervice inmunibus sunt peragit, [sua tanto
+insuper](http://ampycuslyncides.org/), arva ubi: torto mixta. Sanguis
+conscendunt sumit, utilis illo nec quaecumque ad urbis inpositaque. Alto sic
+esse resumere albet, pharetras sola, erat, [non longo
+paviunt](http://verba.org/) dives aurem. Nomina genus nulli insignia, carpere
+dare quo vident, *nox flemus sed* Telamon auras, erant illuc, tantum. Regia
+[duroque opto](http://www.flectathiberi.io/estredeunt), segetes paterna de
+crimen!
+
+    var edutainment_php = plain_ring_scan(adfUgcImap * delPanel);
+    var click_meta_dv = 3 +
+            systemScrollingDocument.snippetCdAnimated.memoryInstallHost(service(
+            bezel_trojan_plagiarism, 1, base_resources), intelligence,
+            umlWiSkin.software_olap.on(quadHocData));
+    var bare = jumper_server_solid - rupE + 3;
+    var timeRegistryStandby = disk_ppc_menu + gigahertzCifsRss;
+    if (im(correction_desktop, disk_integer_soft(serviceLogic, data_zone,
+            daw_ssid_web)) > graphicsExpansionBug + active) {
+        apiSpam = storageVisual + 3;
+    }
+
+Mors cum cum proturbat, gente nasci Semiramis sonum, toto est eris facto dapibus
+propulit; a! Rogantis ira canat, [in nec
+sanguine](http://acceptiordefensus.io/accepto) probro inmunesque molliter
+sustineat quem quamquam parentis non. Per **quod nec** rapit ipsa nec,
+territaque fallacis fluviis progenies aratro. Colla puer regesta si Haec
+silentia omen Paeonia, harenis puer Marmaridae pectora ingens miratur Thisbes
+veri. Plaga profugi, iram, praestans, pro hanc vehit, vites.
+
+Illa per acerris vivit difficile pulveris, faciebat pontus populabile utque? In
+flagrant umbrae marito, coniunx parari, **quoque sanguine Nisi**, ego
+[saxo](http://cervice-fessusque.com/), fovet, ait unda contigit. Gaudet in,
+herba quibus? Ore ne ambo mecumque pectoraque alta: viri illi in puer corpore
+expersque pharetra solutum proximitas. Gorgonis adempto, in montes terga quae
+nec remoratur nives perque insidias exsiluit tribuitque mille.

--- a/__tests__/integration/fixtures/ok-cross-reference/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-cross-reference/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: "Example"
+site_description: "Description Here"
+
+docs_dir: ./docs
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: "index.md"
+  - Subnav:
+    - index.md
+  - Hello: "!include project-a/mkdocs.yml"

--- a/__tests__/integration/fixtures/ok-cross-reference/project-a/docs/README.md
+++ b/__tests__/integration/fixtures/ok-cross-reference/project-a/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the ok/project-a fixture.

--- a/__tests__/integration/fixtures/ok-cross-reference/project-a/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-cross-reference/project-a/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: 'test'
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md
+  - ../cross.md

--- a/__tests__/integration/test.bats
+++ b/__tests__/integration/test.bats
@@ -313,3 +313,9 @@ teardown() {
   assertFileNotContains './site/test/other/other/index.html' 'href="https://github.com/backstage/mkdocs-monorepo-plugin/edit/master/__tests__/integration/fixtures/ok-include-wildcard-no-repo-url/projects/api/docs/other/other.md"'
 }
 
+@test "builds a mkdocs site with cross-referencing from subsite" {
+  cd ${fixturesDir}/ok-cross-reference
+  assertSuccessMkdocs build
+  assertFileContains './site/index.html' 'Cross-referenced'
+}
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.5
+
+-   Allow cross sub-docs reference in `nav`
+
 ## 1.0.4
 
 -   Resolve a bug that prevented this plugin from working with mkdocs >= v1.4.0

--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -296,9 +296,9 @@ class IncludeNavLoader:
                         return "{}/{}".format(alias, value)
 
                 if key is None:
-                    nav[index] = formatNavLink(alias, value)
+                    nav[index] = os.path.normpath(formatNavLink(alias, value))
                 else:
-                    nav[index][key] = formatNavLink(alias, value)
+                    nav[index][key] = os.path.normpath(formatNavLink(alias, value))
 
             elif type(value) == list:
                 nav[index] = {}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='mkdocs-monorepo-plugin',
-    version='1.0.4',
+    version='1.0.5',
     description='Plugin for adding monorepository support in Mkdocs.',
     long_description="""
         This introduces support for the !include syntax in mkdocs.yml, allowing you to import additional Mkdocs navigation.


### PR DESCRIPTION
Sometimes we want to add a page under different subsites (or main site) in a subsite's nav. While linking with ../ may work, but mkdocs can't properly process as it can't find the page.

It shows error like
`WARNING  -  A relative path to 'test/../cross.md' is included in the 'nav' configuration, which is not found in the documentation files`

And the navigation title will be None.

This PR fixes it by having normpath for nav link.