### PR TITLE
Update CI to use all python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3", "3.7"]
+        python-version: ["3", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3, 3.6, 3.7]
+        python-version: ["3", "3.7"]
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3, 3.6, 3.7]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@master
+        uses: actions/setup-python@main
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Bats

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ $ tree .
 
 ## Supported Versions
 
-- Python 3 &mdash; 3.6, 3.7
+- Python 3 &mdash; 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
 - [Mkdocs] 1.0.4 and above.
 
 ## Changelog

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ setuptools.setup(
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.10'
+        'Programming Language :: Python :: 3.11'
     ],
     packages=setuptools.find_packages(),
     entry_points={


### PR DESCRIPTION
Readme says only python 3.6 and 3.7 are supported. I ran the tests with 3.8-3.11 and they seem to pass. Anything else that would block this project from using newer python versions? I had to drop 3.6 from CI though since it is not available anymore in the latest images. Could manually install it in the pipeline if you want also.