### PR TITLE
Replace spotify with backstage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 
 ✚ This plugin enables you to build multiple sets of documentation in a single Mkdocs. It is designed to address writing documentation in Spotify's largest and most business-critical codebases (typically monoliths or monorepos).
 
-✏️ [Blog Post](https://labs.spotify.com/2019/10/01/solving-documentation-for-monoliths-and-monorepos/) | 🐍 [Python Package](https://pypi.org/project/mkdocs-monorepo-plugin/) | ✚ [Demo](https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/) | 📕 [Docs](https://spotify.github.io/mkdocs-monorepo-plugin/)
+✏️ [Blog Post](https://labs.spotify.com/2019/10/01/solving-documentation-for-monoliths-and-monorepos/) | 🐍 [Python Package](https://pypi.org/project/mkdocs-monorepo-plugin/) | ✚ [Demo](https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/) | 📕 [Docs](https://backstage.github.io/mkdocs-monorepo-plugin/)
 
 ## Features
 

--- a/sample-docs/docs/authentication.md
+++ b/sample-docs/docs/authentication.md
@@ -7,4 +7,4 @@ This explains how to authenticate.
 To authenticate, simply pass in your access token in the form of a `Authorization: Bearer {access_token}` header in your HTTP request to our API.
 
 - Markdown source: `sample-docs/docs/authentication.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/authentication/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/authentication/>

--- a/sample-docs/docs/index.md
+++ b/sample-docs/docs/index.md
@@ -9,4 +9,4 @@ This contains the documentation for our Developer Platform.
 - [v3 API Reference](./versions/v3/reference.md)
 
 - Markdown source: `sample-docs/docs/index.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/>

--- a/sample-docs/v1/docs/changelog.md
+++ b/sample-docs/v1/docs/changelog.md
@@ -3,4 +3,4 @@
 This contains the changelog for the v1 API.
 
 - Markdown source: `sample-docs/v1/docs/changelog.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v1/changelog/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v1/changelog/>

--- a/sample-docs/v1/docs/reference.md
+++ b/sample-docs/v1/docs/reference.md
@@ -15,4 +15,4 @@ Parameters:
 Returns a list of cats that match the search query.
 
 - Markdown source: `sample-docs/v1/docs/reference.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v1/reference/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v1/reference/>

--- a/sample-docs/v2/docs/changelog.md
+++ b/sample-docs/v2/docs/changelog.md
@@ -3,4 +3,4 @@
 This contains the changelog for the v2 API.
 
 - Markdown source: `sample-docs/v2/docs/changelog.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v2/changelog/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v2/changelog/>

--- a/sample-docs/v2/docs/migrating.md
+++ b/sample-docs/v2/docs/migrating.md
@@ -3,4 +3,4 @@
 This contains the migration guide to the v2 API from the v1 API.
 
 - Markdown source: `sample-docs/v2/docs/migrating.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v2/migrating/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v2/migrating/>

--- a/sample-docs/v2/docs/reference.md
+++ b/sample-docs/v2/docs/reference.md
@@ -23,4 +23,4 @@ Parameters:
 Returns a list of cats that match the search query.
 
 - Markdown source: `sample-docs/v2/docs/reference.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v2/reference/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v2/reference/>

--- a/sample-docs/v3/docs/changelog.md
+++ b/sample-docs/v3/docs/changelog.md
@@ -3,4 +3,4 @@
 This contains the changelog for the v3 API.
 
 - Markdown source: `sample-docs/v3/docs/changelog.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v3/changelog/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v3/changelog/>

--- a/sample-docs/v3/docs/migrating.md
+++ b/sample-docs/v3/docs/migrating.md
@@ -3,4 +3,4 @@
 This contains the migration guide to the v3 API from the v2 API.
 
 - Markdown source: `sample-docs/v3/docs/migrating.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v3/migrating/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v3/migrating/>

--- a/sample-docs/v3/docs/reference.md
+++ b/sample-docs/v3/docs/reference.md
@@ -23,7 +23,7 @@ Parameters:
 Returns a list of cats that match the search query.
 
 - Markdown source: `sample-docs/v3/docs/reference.md`
-- Permalink: <https://spotify.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v3/reference/>
+- Permalink: <https://backstage.github.io/mkdocs-monorepo-plugin/monorepo-example/versions/v3/reference/>
 
 ## GET /v3/cat/:name/lives_left
 


### PR DESCRIPTION
Replace `spotify.github.io` with `backstage.github.io`. Make sure the demo page and links are linked correctly.