### PR TITLE
Add ability to run script to generate docs

### DIFF
--- a/__tests__/integration/fixtures/ok-with-hook/docs/index.md
+++ b/__tests__/integration/fixtures/ok-with-hook/docs/index.md
@@ -1,0 +1,53 @@
+# Neptunia vapor
+
+## Has mente et
+
+Lorem markdownum aequora Famemque, a ramos regna Ulixem verba, posito qui
+nubilus membra. Pendet dixit canisve, hanc quoque animosa **veni**, inducere.
+Fer quem, mihi vallem; reposcunt aequoreae Haec, inposita. Eras dicere sic! Ore
+ad at nec pius rivi pectora Pandione amari pietas Ulixem.
+
+> Argenteus sinit. Corpore non Booten Uranie, in hac has dixi herbas. *Oculos
+> omnes Dixerat* suae coloribus et antris spernitque silva, dixit.
+
+Mihi [quamvis](http://caput-latebris.com/), ardua venit nam, de mox in et inquit
+incisa relevare reseminet Cycnus forma sororis. In mater artus utque iustis me
+vestrae magno datque, quaque multumque oscula iubemur.
+
+## Aditumque ubi
+
+Brevibus cervice inmunibus sunt peragit, [sua tanto
+insuper](http://ampycuslyncides.org/), arva ubi: torto mixta. Sanguis
+conscendunt sumit, utilis illo nec quaecumque ad urbis inpositaque. Alto sic
+esse resumere albet, pharetras sola, erat, [non longo
+paviunt](http://verba.org/) dives aurem. Nomina genus nulli insignia, carpere
+dare quo vident, *nox flemus sed* Telamon auras, erant illuc, tantum. Regia
+[duroque opto](http://www.flectathiberi.io/estredeunt), segetes paterna de
+crimen!
+
+    var edutainment_php = plain_ring_scan(adfUgcImap * delPanel);
+    var click_meta_dv = 3 +
+            systemScrollingDocument.snippetCdAnimated.memoryInstallHost(service(
+            bezel_trojan_plagiarism, 1, base_resources), intelligence,
+            umlWiSkin.software_olap.on(quadHocData));
+    var bare = jumper_server_solid - rupE + 3;
+    var timeRegistryStandby = disk_ppc_menu + gigahertzCifsRss;
+    if (im(correction_desktop, disk_integer_soft(serviceLogic, data_zone,
+            daw_ssid_web)) > graphicsExpansionBug + active) {
+        apiSpam = storageVisual + 3;
+    }
+
+Mors cum cum proturbat, gente nasci Semiramis sonum, toto est eris facto dapibus
+propulit; a! Rogantis ira canat, [in nec
+sanguine](http://acceptiordefensus.io/accepto) probro inmunesque molliter
+sustineat quem quamquam parentis non. Per **quod nec** rapit ipsa nec,
+territaque fallacis fluviis progenies aratro. Colla puer regesta si Haec
+silentia omen Paeonia, harenis puer Marmaridae pectora ingens miratur Thisbes
+veri. Plaga profugi, iram, praestans, pro hanc vehit, vites.
+
+Illa per acerris vivit difficile pulveris, faciebat pontus populabile utque? In
+flagrant umbrae marito, coniunx parari, **quoque sanguine Nisi**, ego
+[saxo](http://cervice-fessusque.com/), fovet, ait unda contigit. Gaudet in,
+herba quibus? Ore ne ambo mecumque pectoraque alta: viri illi in puer corpore
+expersque pharetra solutum proximitas. Gorgonis adempto, in montes terga quae
+nec remoratur nives perque insidias exsiluit tribuitque mille.

--- a/__tests__/integration/fixtures/ok-with-hook/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-with-hook/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: "Example"
+
+docs_dir: ./docs
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: index.md
+  - project-1: "!include project-2/mkdocs.yml"

--- a/__tests__/integration/fixtures/ok-with-hook/project-1/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-with-hook/project-1/mkdocs.yml
@@ -1,0 +1,11 @@
+
+
+nav:
+  - Home: index.md
+  - About: about.md
+
+
+mono_docs_hook:
+  hook: 
+    - my_hook.py
+    - $TEMP_DOCS_DIR

--- a/__tests__/integration/fixtures/ok-with-hook/project-1/my_hook.py
+++ b/__tests__/integration/fixtures/ok-with-hook/project-1/my_hook.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+temp_docs_dir = Path(sys.argv[1])
+
+with open(temp_docs_dir / "index.md", "w") as md_f:
+    md_f.writelines([
+        "# Hello",
+        "Welcome to project 1's docs!"
+    ])
+
+with open(temp_docs_dir / "about.md", "w") as md_f:
+    md_f.writelines([
+        "# About",
+        "This is the about page."
+    ])

--- a/__tests__/integration/fixtures/ok-with-hook/project-2/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-with-hook/project-2/mkdocs.yml
@@ -1,0 +1,12 @@
+
+
+nav:
+  - Home: index.md
+  - About: about.md
+
+
+mono_docs_hook:
+  cwd: ../project-1
+  hook: 
+    - my_hook.py
+    - $TEMP_DOCS_DIR

--- a/__tests__/integration/test.bats
+++ b/__tests__/integration/test.bats
@@ -198,6 +198,15 @@ teardown() {
   [[ "$output" == *"This contains a sentence which only exists in the ok-include-wildcard/project-b fixture."* ]]
 }
 
+@test "builds a mkdocs site with hooks" {
+  cd ${fixturesDir}/ok-with-hook
+  assertSuccessMkdocs build
+  assertFileExists site/project-1/index.html
+  assertFileExists site/project-1/about.html
+  assertFileExists site/project-2/index.html
+  assertFileExists site/project-2/about.html
+}
+
 @test "fails if !include path is above current folder" {
   cd ${fixturesDir}/error-include-path-is-parent
   assertFailedMkdocs build

--- a/__tests__/test-local.sh
+++ b/__tests__/test-local.sh
@@ -2,8 +2,8 @@
 
 # Lint via flake8
 echo "Running flake8 linter -------->"
-flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=setup.py
-flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=setup.py
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=setup.py,venv,env,.venv,.env
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=setup.py,venv,env,.venv,.env
 
 # Running unit-tests
 python3 -m unittest

--- a/mkdocs_monorepo_plugin/plugin.py
+++ b/mkdocs_monorepo_plugin/plugin.py
@@ -48,7 +48,7 @@ class MonorepoPlugin(BasePlugin):
         self.aliases = {}
         for alias, docs_dir, yaml_file in resolvedPaths:
             self.aliases[alias] = { 'docs_dir': docs_dir, 'yaml_file': yaml_file }
-            self.merger.append(alias, docs_dir)
+            self.merger.append(alias, docs_dir, yaml_file)
         new_docs_dir = self.merger.merge()
 
         # Update the docs_dir with our temporary one!

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='mkdocs-monorepo-plugin',
-    version='1.0.5',
+    version='1.0.6',
     description='Plugin for adding monorepository support in Mkdocs.',
     long_description="""
         This introduces support for the !include syntax in mkdocs.yml, allowing you to import additional Mkdocs navigation.


### PR DESCRIPTION
This PR adds the ability for users to define a `mono_gen_docs_hook` entry in sub-directory (mono package) `mkdocs.yml` files. When merging the docs into the temp directory the script will be called and generated docs will be included in the built site.

## Example

*root mkdocs.yml*
```yaml
plugins:
  - monorepo
  - literate-nav:
      nav_file: SUMMARY.md
```

*sub directory mkdocs.yml*
```yaml
mono_gen_docs_hook:
  hook:
    # writes doc files to the temp docs dir
    - scripts/docs/generate_datamodel_docs.py
    - --doc-dir
    # the env variable is set by the monorepo plugin to be the temp dir
    - $TEMP_DOCS_DIR/datamodel
  python_path: .venv/bin/python


nav:
  - Home: index.md
  - Data Model: datamodel/*
```