### PR TITLE
#107 Remove use of warning_filter (deprecated)

### DIFF
--- a/mkdocs_monorepo_plugin/merger.py
+++ b/mkdocs_monorepo_plugin/merger.py
@@ -20,10 +20,7 @@ import os
 from os.path import join
 from pathlib import Path
 
-from mkdocs.utils import warning_filter
-
 log = logging.getLogger(__name__)
-log.addFilter(warning_filter)
 
 # This collects the multiple docs/ folders and merges them together.
 

--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -19,10 +19,9 @@ import re
 from pathlib import Path
 
 from slugify import slugify
-from mkdocs.utils import yaml_load, warning_filter, dirname_to_title, get_markdown_title
+from mkdocs.utils import yaml_load, dirname_to_title, get_markdown_title
 from urllib.parse import urlsplit
 log = logging.getLogger(__name__)
-log.addFilter(warning_filter)
 
 INCLUDE_STATEMENT = "!include "
 WILDCARD_INCLUDE_STATEMENT = "*include "


### PR DESCRIPTION
Fixes #107

Per #107 Issue, removing the warning_filter as it has been deprecated from mkdocs since version 1.2.

https://www.mkdocs.org/about/release-notes/#version-12-2021-06-04

The mkdocs.utils.warning_filter is deprecated and now does nothing. Plugins should remove any reference to is as it may be deleted in a future release. To ensure any warnings get counted, simply log them to the mkdocs log (i.e.: mkdocs.plugins.pluginname).