### PR TITLE
Remove mkdocs-material from requirements.txt

### DIFF
--- a/__tests__/setup-pip.sh
+++ b/__tests__/setup-pip.sh
@@ -2,3 +2,4 @@
 
 python -m pip install --upgrade pip
 pip install -r requirements.txt
+pip install mkdocs-material=9.2.3

--- a/__tests__/setup-pip.sh
+++ b/__tests__/setup-pip.sh
@@ -2,4 +2,4 @@
 
 python -m pip install --upgrade pip
 pip install -r requirements.txt
-pip install mkdocs-material=9.2.3
+pip install mkdocs-material==9.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs>=1.2.3
 mkdocs-git-authors-plugin==0.3.2
 mkdocs-git-revision-date-localized-plugin==0.5.0
 python-slugify==4.0.1
+importlib-metadata==4.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 flake8>=3.7.8
 mkdocs>=1.2.3
-mkdocs-material>=5.1.0
 mkdocs-git-authors-plugin==0.3.2
 mkdocs-git-revision-date-localized-plugin==0.5.0
 python-slugify==4.0.1


### PR DESCRIPTION
Remove mkdocs-material from requirements.txt as it is only used to generate the documentation site of this plugin, not as actual code dependency