### PR TITLE
Replace distutils copy_tree with shutil.copytree

### DIFF
--- a/mkdocs_monorepo_plugin/merger.py
+++ b/mkdocs_monorepo_plugin/merger.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from tempfile import TemporaryDirectory
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 import logging
 import os
@@ -59,7 +59,7 @@ class Merger:
                 dest_dir = os.path.join(self.temp_docs_dir.name, *split_alias)
 
             if os.path.exists(source_dir):
-                copy_tree(source_dir, dest_dir)
+                copytree(source_dir, dest_dir)
                 for file_abs_path in Path(source_dir).rglob('*.md'):
                     file_abs_path = str(file_abs_path)  # python 3.5 compatibility
                     if os.path.isfile(file_abs_path):


### PR DESCRIPTION
distutils is removed from Python 3.12

fixes:

```
  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/mkdocs_monorepo_plugin/merger.py", line 16, in <module>
    from distutils.dir_util import copy_tree
ModuleNotFoundError: No module named 'distutils'
```