### PR TITLE
Avoid replacing dots for underscores in the documentation url.

### DIFF
--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -257,7 +257,7 @@ class IncludeNavLoader:
 
     def getAlias(self):
         alias = self.navYaml["site_name"]
-        regex = '^[a-zA-Z0-9_\-/]+$'  # noqa: W605
+        regex = '^[a-zA-Z0-9_\.\-/]+$'  # noqa: W605
 
         if re.match(regex, alias) is None:
             alias = slugify(self.navYaml["site_name"])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='mkdocs-monorepo-plugin',
-    version='1.0.5',
+    version='1.0.5.1',
     description='Plugin for adding monorepository support in Mkdocs.',
     long_description="""
         This introduces support for the !include syntax in mkdocs.yml, allowing you to import additional Mkdocs navigation.
@@ -11,7 +11,7 @@ setuptools.setup(
         This is built and maintained by the engineering community at Spotify.
     """,  # noqa: E501
     keywords='mkdocs monorepo',
-    url='https://github.com/backstage/mkdocs-monorepo-plugin',
+    url='https://github.com/bitsondatadev/mkdocs-monorepo-plugin',
     author='Bilawal Hameed',
     author_email='bil@spotify.com',
     license='Apache-2.0',


### PR DESCRIPTION
Many older documentation frameworks don't slugify the `.` character in the url. For us to migrate and use this tool, we had to skip this instance to avoid from breaking the versioned urls.

e.g.
https://iceberg.apache.org/docs/1.2.0/

This new way will require folks to update their folder names to the url name if they are already using `1_2_0` but it will enable both options with this PR. I'm open to hearing a backwards compatible approach that needs to be switched on as well.