### PR TITLE
refactor: replace deprecated package `distutils`

### DIFF
--- a/mkdocs_monorepo_plugin/merger.py
+++ b/mkdocs_monorepo_plugin/merger.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from tempfile import TemporaryDirectory
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 import logging
 import os
@@ -59,7 +59,7 @@ class Merger:
                 dest_dir = os.path.join(self.temp_docs_dir.name, *split_alias)
 
             if os.path.exists(source_dir):
-                copy_tree(source_dir, dest_dir)
+                copytree(source_dir, dest_dir, dirs_exist_ok=True)
                 for file_abs_path in Path(source_dir).rglob('*.md'):
                     file_abs_path = str(file_abs_path)  # python 3.5 compatibility
                     if os.path.isfile(file_abs_path):


### PR DESCRIPTION
`distutils` was deprecated and removed in Python 3.12 [1].

`distutils.dir_util.copy_tree` function can be replaced by the `shutil.copytree` counterpart.

[1]: https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated