### PR TITLE
[v1.1.0] Drop Python 3.7 and add support for Python 3.12

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@master
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install Python dependencies
         run: ./__tests__/setup-pip.sh
       - name: Build Docs
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@master
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Build Python distribution
         run: |
           pip install wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@main

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ $ tree .
 
 ## Supported Versions
 
-- Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
+- Python 3.8, 3.9, 3.10, 3.11, 3.12
 - [Mkdocs] 1.0.4 and above.
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ $ tree .
 
 ## Supported Versions
 
-- Python 3 &mdash; 3.7, 3.8, 3.9, 3.10, 3.11
+- Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
 - [Mkdocs] 1.0.4 and above.
 
 ## Changelog

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.6
+## 1.1.0
 
 -   Dropped official support for Python 3.7
 -   Added official support for Python 3.12

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.6
+
+-   Dropped official support for Python 3.7
+-   Added official support for Python 3.12 and 3.13
+
 ## 1.0.4
 
 -   Resolve a bug that prevented this plugin from working with mkdocs >= v1.4.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Dropped official support for Python 3.7
 -   Added official support for Python 3.12
+-   Replaced deprecated package `distutils` [#118](https://github.com/backstage/mkdocs-monorepo-plugin/pull/118) courtesy of @PauloASilva and @piotr1212
 
 ## 1.0.4
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.6
 
 -   Dropped official support for Python 3.7
--   Added official support for Python 3.12 and 3.13
+-   Added official support for Python 3.12
 
 ## 1.0.4
 

--- a/mkdocs_monorepo_plugin/merger.py
+++ b/mkdocs_monorepo_plugin/merger.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from tempfile import TemporaryDirectory
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 import logging
 import os
@@ -59,7 +59,7 @@ class Merger:
                 dest_dir = os.path.join(self.temp_docs_dir.name, *split_alias)
 
             if os.path.exists(source_dir):
-                copy_tree(source_dir, dest_dir)
+                copytree(source_dir, dest_dir, dirs_exist_ok=True)
                 for file_abs_path in Path(source_dir).rglob('*.md'):
                     file_abs_path = str(file_abs_path)  # python 3.5 compatibility
                     if os.path.isfile(file_abs_path):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='mkdocs-monorepo-plugin',
-    version='1.0.6',
+    version='1.1.0',
     description='Plugin for adding monorepository support in Mkdocs.',
     long_description="""
         This introduces support for the !include syntax in mkdocs.yml, allowing you to import additional Mkdocs navigation.

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13'
+        'Programming Language :: Python :: 3.12'
     ],
     packages=setuptools.find_packages(),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ import setuptools
 
 setuptools.setup(
     name='mkdocs-monorepo-plugin',
-    version='1.0.5',
+    version='1.0.6',
     description='Plugin for adding monorepository support in Mkdocs.',
     long_description="""
         This introduces support for the !include syntax in mkdocs.yml, allowing you to import additional Mkdocs navigation.
         It enables large or complex repositories to have their own sets of docs/ folders, whilst generating only a single Mkdocs site.
-        This is built and maintained by the engineering community at Spotify.
+        This is built and maintained by the Backstage open source team.
     """,  # noqa: E501
     keywords='mkdocs monorepo',
     url='https://github.com/backstage/mkdocs-monorepo-plugin',
@@ -26,11 +26,12 @@ setuptools.setup(
         'Intended Audience :: Information Technology',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13'
     ],
     packages=setuptools.find_packages(),
     entry_points={


### PR DESCRIPTION
Closes #119 

This introduces a change that aligns with Python's active releases. In order to lower maintenance cost and be able to use newer Python features, this is a change that would make it easier to evolve this popular plugin.

This includes the deprecated `distutils` package fix in #115 and #118

This bumps up the version to a major release of 1.1.0