### PR TITLE
feat: add support for monorepos with symlink folders

### DIFF
--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -53,7 +53,7 @@ class Parser:
                         for mkdocs_config in dirs:
                             site = {}
                             if os.path.exists(mkdocs_config):
-                                site[str(mkdocs_config)] = f"{INCLUDE_STATEMENT}{mkdocs_config.resolve()}"
+                                site[str(mkdocs_config)] = f"{INCLUDE_STATEMENT}{mkdocs_config.absolute()}"
                                 value.append(site)
             else:
                 value = None
@@ -114,7 +114,7 @@ class Parser:
                                 with open(mkdocs_config, 'rb') as f:
                                     site_yaml = yaml_load(f)
                                     site_name = site_yaml["site_name"]
-                                site[site_name] = f"{INCLUDE_STATEMENT}{mkdocs_config.resolve()}"
+                                site[site_name] = f"{INCLUDE_STATEMENT}{mkdocs_config.absolute()}"
                                 value.append(site)
                             except OSError:
                                 log.error(f"[mkdocs-monorepo] The {mkdocs_config} path is not valid.")


### PR DESCRIPTION
## Summary

Fixes https://github.com/backstage/mkdocs-monorepo-plugin/issues/121

## Details

This PR adds support for mono-repos that uses symlinks to link 'package dependencies'.

The current behaviour of `mkdocs-monorepo-plugin` is to resolve the `!include` and `*includes` folders to the absolute path by using the `resolve()` path method. The side-effect is though that this method also resolves symlinks, which causes compatibility issues with mono-repos that utilise symlinks to link package dependencies. For example `pnpm` typescript / javascript mono-repos.

By switching the path `.resolve()` method to `.absolute()` the nav paths are still resolved to absolute folders in 'local' context without resolving the symlinks. 

## How it was tested

Manual tested using the folder structure as outlined in https://github.com/backstage/mkdocs-monorepo-plugin/issues/121

## Impact

This is a small breaking change in the folder resolve behaviour, nav paths are still resolved absolute with the exception that links are not resolved to the final target anymore. 

Based on the current plugin setup I expect the impact to be limited. The current plugin version now blocks compilation (given [L175](https://github.com/backstage/mkdocs-monorepo-plugin/blob/b1965a216af41c7e503753c63551d894fac8399d/mkdocs_monorepo_plugin/parser.py#L175)) if that final path resolves to a folder outside of the project directory. So I expect in practise a limited number of projects would be using symlinks today. If needed this could be put behind a plugin feature flag though.