### PR TITLE
fix(edit_uri): realpath page source path in root check

### DIFF
--- a/mkdocs_monorepo_plugin/edit_uri.py
+++ b/mkdocs_monorepo_plugin/edit_uri.py
@@ -97,7 +97,9 @@ class EditUrl:
             abs_root_config_file_dir, root_config_docs_dir
         )
 
-        return path.realpath(abs_root_config_docs_dir) in self.page.file.abs_src_path
+        return path.realpath(abs_root_config_docs_dir) in path.realpath(
+            self.page.file.abs_src_path
+        )
 
     def build(self):
         if self.__is_root():

--- a/mkdocs_monorepo_plugin/tests/test_edit_uri.py
+++ b/mkdocs_monorepo_plugin/tests/test_edit_uri.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from mkdocs_monorepo_plugin.edit_uri import EditUrl
+
+
+class TestEditUri(TestCase):
+    def test_is_root_uses_realpath_for_page_source_path(self):
+        config = {"config_file_path": "/var/folders/work/mkdocs.yml"}
+        page = SimpleNamespace(
+            file=SimpleNamespace(abs_src_path="/var/folders/work/docs/index.md")
+        )
+        plugin = SimpleNamespace(originalDocsDir="/var/folders/work/docs")
+
+        edit_url = EditUrl(config, page, plugin)
+
+        def fake_realpath(value):
+            if value.startswith("/var/folders/work"):
+                return value.replace(
+                    "/var/folders/work", "/private/var/folders/work", 1
+                )
+            return value
+
+        with patch(
+            "mkdocs_monorepo_plugin.edit_uri.path.realpath", side_effect=fake_realpath
+        ):
+            self.assertTrue(edit_url._EditUrl__is_root())


### PR DESCRIPTION
On macOS, paths like `/tmp` and `/var` may resolve to `/private/tmp` and `/private/var` through symlinks.

`EditUrl.__is_root()` compared:
- `realpath(abs_root_config_docs_dir)` (canonicalized)
- `self.page.file.abs_src_path` (non-canonicalized)

This could produce false mismatches when one side includes `/private` and the other does not.

This PR canonicalizes both sides with `path.realpath()` before comparison.

Also added a minimal unit test to reproduce the macOS-style mismatch (`/var/...` vs `/private/var/...`) and validate the fix.
